### PR TITLE
fixed html tags on mobile view of past messages

### DIFF
--- a/app/past-messages/page.tsx
+++ b/app/past-messages/page.tsx
@@ -5,6 +5,7 @@ import { getData } from "@/lib/utils";
 import Link from "next/link";
 import { FC, Suspense } from "react";
 import dateformat from "dateformat";
+import FormattedMessageDisplay from "@/components/common/FormattedMessageDisplay";
 
 interface Props {
   searchParams?: { page: string; query: string };
@@ -68,9 +69,9 @@ const PastMessages: FC<Props> = async ({
                           {dateformat(item.createdAt, "mm/dd/yyyy")}
                         </span>
                       </div>
-                      <p className="text-sm text-primary-dark dark:text-primary-light line-clamp-2 mb-2">
-                        {item.message}
-                      </p>
+                      <div className="text-sm text-primary-dark dark:text-primary-light line-clamp-2 mb-2">
+                        <FormattedMessageDisplay content={item.message} />
+                      </div>
                       <div className="flex justify-between items-center">
                         <span
                           className={`px-2 py-1 text-xs rounded-full ${

--- a/changelog/v2.0.1.md
+++ b/changelog/v2.0.1.md
@@ -1,0 +1,3 @@
+# Version 2.0.1
+
+- Bug Fix - Fixed html tags rendering on the mobile past messages cards

--- a/package-lock.json
+++ b/package-lock.json
@@ -11124,6 +11124,21 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.4.tgz",
+      "integrity": "sha512-WZiz8OdbkpRw6/IU/lredZWKKZopUMhcI2F+XiMAcPja0uZYdMTZQRoQ0WZcvinn9xZAidimE7tN9W5v9Yyfyw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
# Version 2.0.1

- Bug Fix - Fixed html tags rendering on the mobile past messages cards